### PR TITLE
log-domain semirings

### DIFF
--- a/nix-ci-ish
+++ b/nix-ci-ish
@@ -8,11 +8,11 @@ ghcHead="ghcHEAD"
 for g in "${ghcs1709[@]}"
 do
   nix-shell -I nixpkgs=https://github.com/nixos/nixpkgs-channels/archive/nixos-17.09.tar.gz -p haskell.compiler.$g --run "cabal new-build"
-  nix-shell -I nixpkgs=https://github.com/nixos/nixpkgs-channels/archive/nixos-17.09.tar.gz -p haskell.compiler.$g --run "cabal new-build -f-hashable -f-containers -f-unordered-containers -f-vector"
+  nix-shell -I nixpkgs=https://github.com/nixos/nixpkgs-channels/archive/nixos-17.09.tar.gz -p haskell.compiler.$g --run "cabal new-build -f-hashable -f-containers -f-unordered-containers -f-vector -f-log-domain"
 done
 
 for g in "${ghcs1809[@]}"
 do
   nix-shell -I nixpkgs=https://github.com/nixos/nixpkgs-channels/archive/nixos-18.09.tar.gz -p haskell.compiler.$g --run "cabal new-build"
-  nix-shell -I nixpkgs=https://github.com/nixos/nixpkgs-channels/archive/nixos-18.09.tar.gz -p haskell.compiler.$g --run "cabal new-build -f-hashable -f-containers -f-unordered-containers -f-vector"
+  nix-shell -I nixpkgs=https://github.com/nixos/nixpkgs-channels/archive/nixos-18.09.tar.gz -p haskell.compiler.$g --run "cabal new-build -f-hashable -f-containers -f-unordered-containers -f-vector -f-log-domain"
 done

--- a/semirings.cabal
+++ b/semirings.cabal
@@ -46,7 +46,10 @@ tested-with:   GHC == 7.4.1
              , GHC == 8.4.1
              , GHC == 8.4.2
              , GHC == 8.4.3
+             , GHC == 8.4.4
              , GHC == 8.6.1
+             , GHC == 8.6.2
+             , GHC == 8.6.3
 
 source-repository head
   type: git
@@ -86,6 +89,14 @@ flag vector
   default: True
   manual: True
 
+flag log-domain
+  description:
+    You can disable the use of the `log-domain` package using `-f-log-domain`.
+    .
+    Disabling this may be useful for accelerating builds in sandboxes for expert users.
+  default: True
+  manual: True
+
 library
   default-language: Haskell98
   ghc-options: -Wall
@@ -115,13 +126,16 @@ library
       Data.Semiring.Generic
    
     if flag(containers)
-      build-depends: containers >= 0.5.4 && < 0.6.1.0
+      build-depends: containers >= 0.5.4 && < 0.6.1
 
     if flag(hashable)
       build-depends: hashable >= 1.1  && < 1.3
 
-    if flag(hashable) && flag(unordered-containers)
+    if flag(unordered-containers) && flag(hashable)
       build-depends: unordered-containers >= 0.2  && < 0.3
 
     if flag(vector)
-      build-depends: vector >= 0.7 && < 0.13.0.0
+      build-depends: vector >= 0.7 && < 0.13
+    
+    if flag(log-domain) && flag(vector) && flag(hashable)
+      build-depends: log-domain >= 0.10 && < 0.13


### PR DESCRIPTION
this is basically `Tropical 'Maxima a`. `Tropical 'Minima a` is totally valid. Perhaps we should just provide a newtype around `Tropical e a`, like so: `newtype Log e a = Exp { ln :: Tropical e a }`, avoiding the dependencies incurred by `log-domain`, also not restricting us to just the max-plus log-domain semiring.