### PR TITLE
Remove unlawful instances of Ring

### DIFF
--- a/Data/Semiring.hs
+++ b/Data/Semiring.hs
@@ -38,7 +38,7 @@ module Data.Semiring
   , Add(..)
   , Mul(..)
   , WrappedNum(..)
-#if defined(VERSION_containers) && MIN_VERSION_base(4,7,0) 
+#if defined(VERSION_containers) && MIN_VERSION_base(4,7,0)
   , IntSetOf(..)
   , IntMapOf(..)
 #endif
@@ -423,14 +423,14 @@ instance Num.Num a => Ring (WrappedNum a) where
 -- [/additive commutativity/]
 --     @x '+' y = y '+' x@
 -- [/multiplicative left identity/]
---     @'one' '*' x = x@    
+--     @'one' '*' x = x@
 -- [/multiplicative right identity/]
---     @x '*' 'one' = x@ 
+--     @x '*' 'one' = x@
 -- [/multiplicative associativity/]
 --     @x '*' (y '*' z) = (x '*' y) '*' z@
 -- [/left-distributivity of '*' over '+'/]
 --     @x '*' (y '+' z) = (x '*' y) '+' (x '*' z)@
--- [/right-distributivity of '*' over '+'/]   
+-- [/right-distributivity of '*' over '+'/]
 --     @(x '+' y) '*' z = (x '*' z) '+' (y '*' z)@
 -- [/annihilation/]
 --     @'zero' '*' x = x '*' 'zero' = 'zero'@
@@ -514,10 +514,6 @@ instance Semiring Bool where
   {-# INLINE times #-}
   {-# INLINE one   #-}
 
-instance Ring Bool where
-  negate = not
-  {-# INLINE negate #-}
-
 -- | The 'Semiring' instance for '[a]' can be interpreted as
 --   treating each element of the list as coefficients to a
 --   polynomial in one variable.
@@ -538,10 +534,6 @@ instance Semiring a => Semiring [a] where
   {-# INLINE times #-}
   {-# INLINE one   #-}
 
-instance Ring a => Ring [a] where
-  negate = fmap negate
-  {-# INLINE negate #-}
-
 instance Semiring a => Semiring (Maybe a) where
   zero  = Nothing
   one   = Just one
@@ -557,10 +549,6 @@ instance Semiring a => Semiring (Maybe a) where
   {-# INLINE zero  #-}
   {-# INLINE times #-}
   {-# INLINE one   #-}
-
-instance Ring a => Ring (Maybe a) where
-  negate = fmap negate
-  {-# INLINE negate #-}
 
 instance Semiring a => Semiring (IO a) where
   zero  = pure zero
@@ -638,10 +626,8 @@ instance (Ring a, Applicative f) => Ring (Ap f a) where
 
 #if MIN_VERSION_base(4,12,0)
 deriving instance Semiring (Predicate a)
-deriving instance Ring (Predicate a)
 
 deriving instance Semiring a => Semiring (Equivalence a)
-deriving instance Ring a => Ring (Equivalence a)
 
 deriving instance Semiring a => Semiring (Op a b)
 deriving instance Ring a => Ring (Op a b)
@@ -1043,10 +1029,6 @@ instance Semiring a => Semiring (Vector a) where
   {-# INLINE times #-}
   {-# INLINE one   #-}
 
-instance Ring a => Ring (Vector a) where
-  negate = Vector.map negate
-  {-# INLINE negate #-}
-
 instance (UV.Unbox a, Semiring a) => Semiring (UV.Vector a) where
   zero = UV.empty
   one  = UV.singleton one
@@ -1076,10 +1058,6 @@ instance (UV.Unbox a, Semiring a) => Semiring (UV.Vector a) where
   {-# INLINE zero  #-}
   {-# INLINE times #-}
   {-# INLINE one   #-}
-
-instance (UV.Unbox a, Ring a) => Ring (UV.Vector a) where
-  negate = UV.map negate
-  {-# INLINE negate #-}
 
 instance (SV.Storable a, Semiring a) => Semiring (SV.Vector a) where
   zero = SV.empty
@@ -1112,10 +1090,6 @@ instance (SV.Storable a, Semiring a) => Semiring (SV.Vector a) where
   {-# INLINE zero  #-}
   {-# INLINE times #-}
   {-# INLINE one   #-}
-
-instance (SV.Storable a, Ring a) => Ring (SV.Vector a) where
-  negate = SV.map negate
-  {-# INLINE negate #-}
 #endif
 
 -- [Section: List fusion]

--- a/test/main.hs
+++ b/test/main.hs
@@ -45,59 +45,62 @@ import qualified Test.QuickCheck.Classes as QCC
 
 type Laws = QCC.Laws
 
-myLaws :: (Arbitrary a, Show a, Eq a, Semiring a) => Proxy a -> [Laws]
-myLaws p = [QCC.semiringLaws p]
+semiringLaws :: (Arbitrary a, Show a, Eq a, Semiring a) => Proxy a -> [Laws]
+semiringLaws p = [QCC.semiringLaws p]
+
+ringLaws :: (Arbitrary a, Show a, Eq a, Ring a) => Proxy a -> [Laws]
+ringLaws p = [QCC.semiringLaws p, QCC.ringLaws p]
 
 namedTests :: [(String, [Laws])]
 namedTests =
-  [ ("Bool", myLaws pBool)
---  , ("Double", myLaws pDouble) -- needs to be within some epsilon
---  , ("Float", myLaws pFloat)   -- needs to be within some epsilon
---  , ("Complex", myLaws pComplex) -- needs to be within some epsilon
-  , ("Int", myLaws pInt)
-  , ("Int8", myLaws pInt8)
-  , ("Int16", myLaws pInt16)
-  , ("Int32", myLaws pInt32)
-  , ("Int64", myLaws pInt64)
-  , ("Word", myLaws pWord)
-  , ("Word8", myLaws pWord8)
-  , ("Word16", myLaws pWord16)
-  , ("Word32", myLaws pWord32)
-  , ("Word64", myLaws pWord64)
-  , ("()", myLaws pUnit)
-  , ("[]", myLaws pList)
-  , ("Maybe", myLaws pMaybe)
-  , ("PosRatio", myLaws pPosRatio)
-  , ("IO", myLaws pIO)
-  , ("Fixed", myLaws pFixed)
-  , ("Identity", myLaws pIdentity)
-  , ("Dual", myLaws pDual)
-  , ("(->)", myLaws pFunction)
-  , ("Down", myLaws pDown)
-  , ("Const", myLaws pConst)
---  , ("IntMap", myLaws pIntMap) -- needs newtypes
-  , ("Set", myLaws pSet)
---  , ("IntSet", myLaws pIntSet) -- needs newtypes
-  , ("HashSet", myLaws pHashSet)
-  , ("HashMap", myLaws pHashMap)
-  , ("Vector", myLaws pVector)
-  , ("Storable Vector", myLaws pStorableVector)
-  , ("Unboxed Vector", myLaws pUnboxedVector)
-  , ("Map", myLaws pMap)
-  , ("Predicate", myLaws pPredicate)
-  , ("Equivalence", myLaws pEquivalence)
-  , ("Op", myLaws pOp)
-  , ("Ap", myLaws pAp)
+  [ ("Bool", ringLaws pBool)
+--  , ("Double", ringLaws pDouble) -- needs to be within some epsilon
+--  , ("Float", ringLaws pFloat)   -- needs to be within some epsilon
+--  , ("Complex", ringLaws pComplex) -- needs to be within some epsilon
+  , ("Int", ringLaws pInt)
+  , ("Int8", ringLaws pInt8)
+  , ("Int16", ringLaws pInt16)
+  , ("Int32", ringLaws pInt32)
+  , ("Int64", ringLaws pInt64)
+  , ("Word", ringLaws pWord)
+  , ("Word8", ringLaws pWord8)
+  , ("Word16", ringLaws pWord16)
+  , ("Word32", ringLaws pWord32)
+  , ("Word64", ringLaws pWord64)
+  , ("()", ringLaws pUnit)
+  , ("[]", ringLaws pList)
+  , ("Maybe", ringLaws pMaybe)
+  , ("PosRatio", semiringLaws pPosRatio)
+  , ("IO", ringLaws pIO)
+  , ("Fixed", ringLaws pFixed)
+  , ("Identity", ringLaws pIdentity)
+  , ("Dual", ringLaws pDual)
+  , ("(->)", ringLaws pFunction)
+  , ("Down", ringLaws pDown)
+  , ("Const", ringLaws pConst)
+--  , ("IntMap", semiringLaws pIntMap) -- needs newtypes
+  , ("Set", semiringLaws pSet)
+--  , ("IntSet", semiringLaws pIntSet) -- needs newtypes
+  , ("HashSet", semiringLaws pHashSet)
+  , ("HashMap", semiringLaws pHashMap)
+  , ("Vector", ringLaws pVector)
+  , ("Storable Vector", ringLaws pStorableVector)
+  , ("Unboxed Vector", ringLaws pUnboxedVector)
+  , ("Map", semiringLaws pMap)
+  , ("Predicate", ringLaws pPredicate)
+  , ("Equivalence", ringLaws pEquivalence)
+  , ("Op", ringLaws pOp)
+  , ("Ap", ringLaws pAp)
 
-  , ("IntSet Sum", myLaws pIntSetSum)
-  , ("IntSet Product", myLaws pIntSetProduct)
-  , ("IntSet Min", myLaws pIntSetMin)
-  , ("IntSet Max", myLaws pIntSetMax)
+  , ("IntSet Sum", semiringLaws pIntSetSum)
+  , ("IntSet Product", semiringLaws pIntSetProduct)
+  , ("IntSet Min", semiringLaws pIntSetMin)
+  , ("IntSet Max", semiringLaws pIntSetMax)
 
-  , ("IntMap Sum", myLaws pIntMapSum)
-  , ("IntMap Product", myLaws pIntMapProduct)
-  , ("IntMap Min", myLaws pIntMapMin)
-  , ("IntMap Max", myLaws pIntMapMax)
+  , ("IntMap Sum", semiringLaws pIntMapSum)
+  , ("IntMap Product", semiringLaws pIntMapProduct)
+  , ("IntMap Min", semiringLaws pIntMapMin)
+  , ("IntMap Max", semiringLaws pIntMapMax)
   ]
 
 #if !(MIN_VERSION_base(4,12,0))

--- a/test/main.hs
+++ b/test/main.hs
@@ -53,7 +53,7 @@ ringLaws p = [QCC.semiringLaws p, QCC.ringLaws p]
 
 namedTests :: [(String, [Laws])]
 namedTests =
-  [ ("Bool", ringLaws pBool)
+  [ ("Bool", semiringLaws pBool)
 --  , ("Double", ringLaws pDouble) -- needs to be within some epsilon
 --  , ("Float", ringLaws pFloat)   -- needs to be within some epsilon
 --  , ("Complex", ringLaws pComplex) -- needs to be within some epsilon
@@ -68,8 +68,8 @@ namedTests =
   , ("Word32", ringLaws pWord32)
   , ("Word64", ringLaws pWord64)
   , ("()", ringLaws pUnit)
-  , ("[]", ringLaws pList)
-  , ("Maybe", ringLaws pMaybe)
+  , ("[]", semiringLaws pList)
+  , ("Maybe", semiringLaws pMaybe)
   , ("PosRatio", semiringLaws pPosRatio)
   , ("IO", ringLaws pIO)
   , ("Fixed", ringLaws pFixed)
@@ -83,12 +83,12 @@ namedTests =
 --  , ("IntSet", semiringLaws pIntSet) -- needs newtypes
   , ("HashSet", semiringLaws pHashSet)
   , ("HashMap", semiringLaws pHashMap)
-  , ("Vector", ringLaws pVector)
-  , ("Storable Vector", ringLaws pStorableVector)
-  , ("Unboxed Vector", ringLaws pUnboxedVector)
+  , ("Vector", semiringLaws pVector)
+  , ("Storable Vector", semiringLaws pStorableVector)
+  , ("Unboxed Vector", semiringLaws pUnboxedVector)
   , ("Map", semiringLaws pMap)
-  , ("Predicate", ringLaws pPredicate)
-  , ("Equivalence", ringLaws pEquivalence)
+  , ("Predicate", semiringLaws pPredicate)
+  , ("Equivalence", semiringLaws pEquivalence)
   , ("Op", ringLaws pOp)
   , ("Ap", ringLaws pAp)
 
@@ -117,13 +117,11 @@ deriving instance (Arbitrary (f a)) => Arbitrary (Ap f a)
 newtype Predicate a = Predicate (a -> Bool)
   deriving (Eq, Show)
 deriving instance Semiring (Predicate a)
-deriving instance Ring (Predicate a)
 deriving instance (Arbitrary a, CoArbitrary a) => Arbitrary (Predicate a)
 
 newtype Equivalence a = Equivalence (a -> a -> Bool)
   deriving (Eq, Show)
 deriving instance Semiring a => Semiring (Equivalence a)
-deriving instance Ring a => Ring (Equivalence a)
 deriving instance (Arbitrary a, CoArbitrary a) => Arbitrary (Equivalence a)
 
 newtype Op a b = Op (b -> a)


### PR DESCRIPTION
Pondering about #36, I discovered that we have many `Ring` instances for non-numeric datatypes, which surprised me. It appears that several of them are unlawful, so I removed them. 