### PR TITLE
Add fromNatural

### DIFF
--- a/Data/Semiring/Tropical.hs
+++ b/Data/Semiring/Tropical.hs
@@ -123,6 +123,8 @@ instance forall e a. (Ord a, Monoid.Monoid a, Extremum e) => Semiring (Tropical 
   times Infinity _ = Infinity
   times _ Infinity = Infinity
   times (Tropical x) (Tropical y) = Tropical (Monoid.mappend x y)
+  fromNatural 0 = zero
+  fromNatural _ = one
 
 instance forall e a. (Ord a, Monoid.Monoid a, Extremum e) => Star (Tropical e a) where
   star _ = one


### PR DESCRIPTION
There is a homomorphism between an additive semigroup of non-negative integers and an arbitrary semiring `S`:

```
h : N -> S
h(0) = 0
h(n) = 1 + ... + 1 (n times)
```

This homomorphism is very useful, when we want to multiply an element of the ring by an integer `n` (e. g., taking a derivative of a polynomial with coefficients from a semiring). It can be expressed in terms of `stimes` over a semigroup `Add`, but for the majority of semirings a more efficient implementation is available.

The PR introduces the homomorphism `fromNatural` with a default implementation in terms of `zero` and `one` (and vice versa). It also adds an improved implementation of `stimes` to the definition of semigroup `Add`. 

If this sounds reasonable, I'll add tests for `fromNatural` to `quickcheck-classes`.