### PR TITLE
Bump upper bound for hashables

### DIFF
--- a/semirings.cabal
+++ b/semirings.cabal
@@ -116,7 +116,7 @@ library
       build-depends: containers >= 0.5.4 && < 0.6.1.0
 
     if flag(hashable)
-      build-depends: hashable >= 1.1  && < 1.3
+      build-depends: hashable >= 1.1  && < 1.4
 
     if flag(hashable) && flag(unordered-containers)
       build-depends: unordered-containers >= 0.2  && < 0.3


### PR DESCRIPTION
Required to allow it to be built with ghc 8.8.0.

I (as a Hackage trustee) have already bumped the under bound on Hackage. This PR is update the bound here.