### PR TITLE
Implement extended gcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+TBA
+---
+* Add `gcdExt` function
+
 0.5.1: [2019.09.13]
 -------------------
 * Bump upper bound on containers to 0.7

--- a/Data/Euclidean.hs
+++ b/Data/Euclidean.hs
@@ -16,6 +16,7 @@ module Data.Euclidean
   , GcdDomain(..)
   , WrappedIntegral(..)
   , WrappedFractional(..)
+  , gcdExt
   ) where
 
 import Prelude hiding (quotRem, quot, rem, divMod, div, mod, gcd, lcm, negate, (*))
@@ -147,7 +148,19 @@ infixl 7 `rem`
 coprimeIntegral :: Integral a => a -> a -> Bool
 coprimeIntegral x y = (odd x || odd y) && P.gcd x y == 1
 
--- | A 'Field' represents a
+-- | Execute the extended Euclidean algorithm.
+-- For elements @a@ and @b@, compute their greatest common divisor @g@
+-- and the coefficient @s@ satisfying @as + bt = g@.
+gcdExt :: (Eq a, Euclidean a, Ring a) => a -> a -> (a, a)
+gcdExt = go one zero
+  where
+    go s s' r r'
+      | r' == zero = (r, s)
+      | otherwise  = case quotRem r r' of
+        (q, r'') -> go s' (minus s (times q s')) r' r''
+{-# INLINE gcdExt #-}
+
+-- | 'Field' represents a
 -- <https://en.wikipedia.org/wiki/Field_(mathematics) field>,
 -- a ring with a multiplicative inverse for any non-zero element.
 class (Euclidean a, Ring a) => Field a

--- a/Data/Euclidean.hs
+++ b/Data/Euclidean.hs
@@ -150,7 +150,7 @@ coprimeIntegral x y = (odd x || odd y) && P.gcd x y == 1
 
 -- | Execute the extended Euclidean algorithm.
 -- For elements @a@ and @b@, compute their greatest common divisor @g@
--- and the coefficient @s@ satisfying @as + bt = g@.
+-- and the coefficient @s@ satisfying @as + bt = g@ for some @t@.
 gcdExt :: (Eq a, Euclidean a, Ring a) => a -> a -> (a, a)
 gcdExt = go one zero
   where
@@ -158,7 +158,7 @@ gcdExt = go one zero
       | r' == zero = (r, s)
       | otherwise  = case quotRem r r' of
         (q, r'') -> go s' (minus s (times q s')) r' r''
-{-# INLINE gcdExt #-}
+{-# INLINABLE gcdExt #-}
 
 -- | 'Field' represents a
 -- <https://en.wikipedia.org/wiki/Field_(mathematics) field>,

--- a/test/main.hs
+++ b/test/main.hs
@@ -10,7 +10,7 @@ import Control.Monad ((>=>),forM)
 import Control.Applicative (liftA2)
 import Data.Complex
 import Data.Either
-import Data.Euclidean
+import Data.Euclidean hiding (gcd)
 import Data.Fixed
 import Data.Functor.Const
 import Data.Functor.Identity
@@ -50,6 +50,7 @@ main :: IO ()
 main = do
   QCC.lawsCheckMany namedTests
   F.fold pow_prop
+  F.fold gcd_prop
 
 forceError :: a -> IO (Either E.ErrorCall a)
 forceError = E.try . E.evaluate
@@ -73,6 +74,17 @@ pow_prop3 x = ioProperty $ do
   case p of
     Left e -> pure False
     Right x -> pure $ x == 1
+
+gcd_prop :: [IO ()]
+gcd_prop = [quickCheck gcd_prop1, quickCheck gcd_prop2]
+
+gcd_prop1 :: Integer -> Integer -> Property
+gcd_prop1 x y = Num.abs (fst (x `gcdExt` y)) === x `gcd` y
+
+gcd_prop2 :: Integer -> Integer -> Property
+gcd_prop2 x y = y /= 0 ==> (x * s) `mod` y === g `mod` y
+  where
+    (g, s) = x `gcdExt` y
 
 type Laws = QCC.Laws
 


### PR DESCRIPTION
Addresses #52 

The tuple returned by `gcdExt` is currently unique only up to units, as I cannot think of a way to make a preference between associates, unlike the implementations in `bitvec` or `poly`.