### PR TITLE
Add lower bound on integer-gmp

### DIFF
--- a/semirings.cabal
+++ b/semirings.cabal
@@ -73,7 +73,7 @@ library
 
   build-depends:
       base >= 4.5 && < 5
-    , integer-gmp
+    , integer-gmp >= 1.0.0.0
 
   if impl(ghc < 7.10)
     build-depends:


### PR DESCRIPTION
GcdDomain Word instance requires gcdWord to be exported from integer-gmp.
That only happened starting in version 1.0.0.0

This was breaking the travis builds on old ghcs