### PR TITLE
Extract divide into a new IntegralDomain class

### DIFF
--- a/Data/Euclidean.hs-boot
+++ b/Data/Euclidean.hs-boot
@@ -1,0 +1,28 @@
+module Data.Euclidean where
+
+import           Numeric.Natural                ( Natural )
+import {-# SOURCE #-} Data.Semiring             ( IntegralDomain )
+import           Prelude                 hiding ( quot
+                                                , rem
+                                                , quotRem
+                                                )
+
+class GcdDomain a
+
+class GcdDomain a => Euclidean a where
+  quotRem :: a -> a -> (a, a)
+  quotRem x y = (quot x y, rem x y)
+  quot :: a -> a -> a
+  quot x y = fst (quotRem x y)
+  rem :: a -> a -> a
+  rem x y = snd (quotRem x y)
+  degree :: a -> Natural
+  {-# MINIMAL (quotRem | quot, rem), degree #-}
+
+class Field a
+
+newtype WrappedIntegral a = WrapIntegral { unwrapIntegral :: a }
+newtype WrappedFractional a = WrapFractional { unwrapFractional :: a }
+
+instance Integral a => IntegralDomain (WrappedIntegral a)
+instance Fractional a => IntegralDomain (WrappedFractional a)

--- a/Data/Semiring.hs-boot
+++ b/Data/Semiring.hs-boot
@@ -1,0 +1,3 @@
+module Data.Semiring where
+
+class IntegralDomain a


### PR DESCRIPTION
Closes #62. Based on #64, though if that is rejected can be CPPifyed

Unfortunately, to still be able to provide default implementations we have
import cycles. These can be avoided by moving `IntegralDomain` into
Euclidean.hs, though it is unclear that the name would then still be
appropriate.

Cycles caused mainly by:
* Use of `WrappedIntegral`/`WrappedFractional` for `DerivingVia`
  instances for `IntegralDomain`
* `GcdDomain` now needs `IntegralDomain` context

In addition, to minimize context, added `Fractional (Complex a)` constraint to
the `Complex a` instances, which GHC dislikes. If the required extensions are
unpalatable, the constraint needs to be replaced with a `RealFrac a` constraint.

Not all types got a `IntegralDomain` instance, since I couldn't work out
what they should be. These include the 'containers' types and `IO`.