### PR TITLE
Do not depend on integer-gmp

### DIFF
--- a/Data/Euclidean.hs
+++ b/Data/Euclidean.hs
@@ -30,8 +30,6 @@ import Data.Ratio (Ratio)
 import Data.Semiring (Semiring(..), Ring(..), (*), minus, isZero, Mod2)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
 import Foreign.C.Types (CFloat, CDouble)
-import GHC.Exts (Int(..), Word(..))
-import GHC.Integer.GMP.Internals (gcdInt, gcdWord, gcdInteger, lcmInteger)
 
 import Numeric.Natural
 
@@ -227,32 +225,6 @@ instance Integral a => Euclidean (WrappedIntegral a) where
   quot    = P.quot
   rem     = P.rem
 
-instance GcdDomain Int where
-  divide x y = case x `P.quotRem` y of (q, 0) -> Just q; _ -> Nothing
-#if MIN_VERSION_integer_gmp(0,5,1)
-  gcd (I# x) (I# y) = I# (gcdInt x y)
-#else
-  gcd     = P.gcd
-#endif
-  lcm     = P.lcm
-  coprime = coprimeIntegral
-
-instance GcdDomain Word where
-  divide x y = case x `P.quotRem` y of (q, 0) -> Just q; _ -> Nothing
-#if MIN_VERSION_integer_gmp(1,0,0)
-  gcd (W# x) (W# y) = W# (gcdWord x y)
-#else
-  gcd     = P.gcd
-#endif
-  lcm     = P.lcm
-  coprime = coprimeIntegral
-
-instance GcdDomain Integer where
-  divide x y = case x `P.quotRem` y of (q, 0) -> Just q; _ -> Nothing
-  gcd     = gcdInteger
-  lcm     = lcmInteger
-  coprime = coprimeIntegral
-
 #define deriveGcdDomain(ty)     \
 instance GcdDomain (ty) where { \
 ;  divide x y = case x `P.quotRem` y of { (q, 0) -> Just q; _ -> Nothing } \
@@ -261,10 +233,13 @@ instance GcdDomain (ty) where { \
 ;  coprime = coprimeIntegral    \
 }
 
+deriveGcdDomain(Int)
 deriveGcdDomain(Int8)
 deriveGcdDomain(Int16)
 deriveGcdDomain(Int32)
 deriveGcdDomain(Int64)
+deriveGcdDomain(Integer)
+deriveGcdDomain(Word)
 deriveGcdDomain(Word8)
 deriveGcdDomain(Word16)
 deriveGcdDomain(Word32)

--- a/Data/Semiring.hs
+++ b/Data/Semiring.hs
@@ -118,13 +118,13 @@ import           GHC.Err (error)
 import           GHC.Float (Float, Double)
 import           GHC.Generics (Generic,Generic1)
 import           GHC.IO (IO)
-import           GHC.Integer (Integer)
 import qualified GHC.Num as Num
 import           GHC.Read (Read)
 import           GHC.Real (Integral, Fractional, Real, RealFrac)
 import qualified GHC.Real as Real
 import           GHC.Show (Show)
 import           Numeric.Natural (Natural)
+import           Prelude (Integer)
 
 #ifdef mingw32_HOST_OS
 #define HOST_OS_WINDOWS 1

--- a/semirings.cabal
+++ b/semirings.cabal
@@ -74,7 +74,6 @@ library
   build-depends:
       base >= 4.8 && < 5
     , base-compat-batteries
-    , integer-gmp >= 0.1.0.0
   exposed-modules:
     Data.Euclidean
     Data.Field


### PR DESCRIPTION
`integer-gmp-1.1` (part of upcoming GHC 9.0 release) introduces several breaking changes: `gcdInt` / `gcdWord` are removed, and `gcdInteger` /  `lcmInteger` are deprecated. The simplest solution is just to use monomorphic `gcd` / `lcm` in respective instances and let GHC specialise them on its own, when possible. 