### PR TITLE
Add Directed - a Semiring for Ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.7: [2021-07-09]
+-----------------
+* Add `Semiring` instance for `Ordering`
+
 0.6: [2021-01-07]
 -----------------
 * Remove hashable flag (only necessary was unordered-containers flag)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 0.7: [2021-07-09]
 -----------------
-* Add `Semiring` instance for `Ordering`
+* Add `Data.Semiring.Directed` for the semiring of directed sets.
 
 0.6: [2021-01-07]
 -----------------

--- a/Data/Semiring.hs
+++ b/Data/Semiring.hs
@@ -97,7 +97,7 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 #endif
 import           Data.Monoid (Monoid(..), Dual(..))
-import           Data.Ord (Ord((<)), (>=))
+import           Data.Ord (Ord((<)), (>=), Ordering (LT, EQ, GT))
 import           Data.Ord (Down(..))
 import           Data.Proxy (Proxy(..))
 import           Data.Ratio (Ratio, Rational, (%))
@@ -503,6 +503,27 @@ fromIntegral x
 {--------------------------------------------------------------------
   Instances (base)
 --------------------------------------------------------------------}
+
+-- | @since 0.7
+instance Semiring Ordering where
+  {-# INLINE plus #-}
+  plus LT t = t
+  plus t LT = t
+  plus EQ GT = GT
+  plus GT EQ = GT
+  plus EQ EQ = EQ
+  plus GT GT = GT
+  {-# INLINE zero #-}
+  zero = LT
+  {-# INLINE times #-}
+  times LT _ = LT
+  times _ LT = LT
+  times EQ GT = EQ
+  times GT EQ = EQ
+  times EQ EQ = EQ
+  times GT GT = GT
+  {-# INLINE one #-}
+  one = GT
 
 instance Semiring b => Semiring (a -> b) where
   plus f g    = \x -> f x `plus` g x

--- a/Data/Semiring.hs
+++ b/Data/Semiring.hs
@@ -97,7 +97,7 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 #endif
 import           Data.Monoid (Monoid(..), Dual(..))
-import           Data.Ord (Ord((<)), (>=), Ordering (LT, EQ, GT))
+import           Data.Ord (Ord((<)), (>=))
 import           Data.Ord (Down(..))
 import           Data.Proxy (Proxy(..))
 import           Data.Ratio (Ratio, Rational, (%))
@@ -503,27 +503,6 @@ fromIntegral x
 {--------------------------------------------------------------------
   Instances (base)
 --------------------------------------------------------------------}
-
--- | @since 0.7
-instance Semiring Ordering where
-  {-# INLINE plus #-}
-  plus LT t = t
-  plus t LT = t
-  plus EQ GT = GT
-  plus GT EQ = GT
-  plus EQ EQ = EQ
-  plus GT GT = GT
-  {-# INLINE zero #-}
-  zero = LT
-  {-# INLINE times #-}
-  times LT _ = LT
-  times _ LT = LT
-  times EQ GT = EQ
-  times GT EQ = EQ
-  times EQ EQ = EQ
-  times GT GT = GT
-  {-# INLINE one #-}
-  one = GT
 
 instance Semiring b => Semiring (a -> b) where
   plus f g    = \x -> f x `plus` g x

--- a/Data/Semiring/Directed.hs
+++ b/Data/Semiring/Directed.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE Trustworthy                #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -33,57 +34,69 @@ import GHC.Generics (Generic)
 
 -- | As it is above.
 --
--- @Above@ provides the monoid associated with the union of upward-directed sets.
-newtype Above = Above { getAbove :: Ordering }
+-- 'Above' provides the monoid associated with the union of upward-directed sets.
+--
+-- @since 0.7
+newtype Above = Above { 
+  -- | @since 0.7
+  getAbove :: Ordering 
+  }
   deriving
-    ( Bounded
-    , Enum
-    , Eq
-    , Generic
-    , Show
-    , Read
+    ( Bounded -- ^ @since 0.7
+    , Enum -- ^ @since 0.7
+    , Eq -- ^ @since 0.7
+    , Generic  -- ^ @since 0.7
+    , Show -- ^ @since 0.7
+    , Read -- ^ @since 0.7
 #if MIN_VERSION_base(4,7,0)
-    , Data
-    , Typeable
+    , Data -- ^ @since 0.7
+    , Typeable -- ^ @since 0.7
 #endif
     )
 
+-- | @since 0.7
 instance Semigroup Above where
   Above LT <> a = a
   a <> Above LT = a
   Above EQ <> Above EQ = Above EQ
-  Above EQ <> Above GT = Above GT
-  Above GT <> Above EQ = Above GT
-  Above GT <> Above GT = Above GT
+  _ <> Above GT = Above GT
+  Above GT <> _ = Above GT
 
+-- | @since 0.7
 instance Monoid Above where
   mempty = Above LT
 
 -- | So it shall be below.
 --
--- @Below@ provides the monoid associated with the intersection of downward-directed sets.
-newtype Below = Below { getBelow :: Ordering }
+-- 'Below' provides the monoid associated with the intersection of downward-directed sets.
+--
+-- @since 0.7
+newtype Below = Below { 
+  -- | @since 0.7
+  getBelow :: Ordering 
+  }
   deriving
-    ( Bounded
-    , Enum
-    , Eq
-    , Generic
-    , Show
-    , Read
+    ( Bounded -- ^ @since 0.7
+    , Enum -- ^ @since 0.7
+    , Eq -- ^ @since 0.7
+    , Generic  -- ^ @since 0.7
+    , Show -- ^ @since 0.7
+    , Read -- ^ @since 0.7
 #if MIN_VERSION_base(4,7,0)
-    , Data
-    , Typeable
+    , Data -- ^ @since 0.7
+    , Typeable -- ^ @since 0.7
 #endif
     )
 
+-- | @since 0.7
 instance Semigroup Below where
   Below GT <> a = a
   a <> Below GT = a
   Below EQ <> Below EQ = Below EQ
-  Below EQ <> Below LT = Below LT
-  Below LT <> Below EQ = Below LT
-  Below LT <> Below LT = Below LT
+  Below EQ <> _ = Below LT
+  _ <> Below EQ = Below LT
 
+-- | @since 0.7
 instance Monoid Below where
   mempty = Below GT
 
@@ -91,20 +104,24 @@ instance Monoid Below where
 --
 -- For the individual join/meet monoids associated with either
 -- algebra, see 'Above', and 'Below'.
-newtype Directed = Directed { getDirected :: Ordering }
+newtype Directed = Directed { 
+  -- | @since 0.7
+  getDirected :: Ordering 
+  }
   deriving
-    ( Bounded
-    , Enum
-    , Eq
-    , Generic
-    , Show
-    , Read
+    ( Bounded -- ^ @since 0.7
+    , Enum -- ^ @since 0.7
+    , Eq -- ^ @since 0.7
+    , Generic  -- ^ @since 0.7
+    , Show -- ^ @since 0.7
+    , Read -- ^ @since 0.7
 #if MIN_VERSION_base(4,7,0)
-    , Data
-    , Typeable
+    , Data -- ^ @since 0.7
+    , Typeable -- ^ @since 0.7
 #endif
     )
 
+-- | @since 0.7
 instance Semiring Directed where
   plus = coerce ((<>) :: Above -> Above -> Above)
   zero = coerce (mempty :: Above)

--- a/Data/Semiring/Directed.hs
+++ b/Data/Semiring/Directed.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+-----------------------------------------------------------------------------
+-- |
+--   A "directed semiring" refers to the semiring composed of the union of upwards
+--   directed sets as multiplication, and intersection of downwards directed sets
+--   as addition.
+-----------------------------------------------------------------------------
+module Data.Semiring.Directed
+  ( -- * Directed semirings
+    Directed(..)
+  , Above(..)
+  , Below(..)
+  ) where
+
+#if MIN_VERSION_base(4,7,0)
+import Data.Data (Data)
+#endif
+import Data.Coerce (coerce)
+import Data.Semiring (Semiring(..))
+#if MIN_VERSION_base(4,7,0)
+import Data.Typeable (Typeable)
+#endif
+
+import GHC.Generics (Generic)
+
+
+-- | As it is above.
+--
+-- @Above@ provides the monoid associated with the union of upward-directed sets.
+newtype Above = Above { getAbove :: Ordering }
+  deriving
+    ( Bounded
+    , Enum
+    , Eq
+    , Generic
+    , Show
+    , Read
+#if MIN_VERSION_base(4,7,0)
+    , Data
+    , Typeable
+#endif
+    )
+
+instance Semigroup Above where
+  Above LT <> a = a
+  a <> Above LT = a
+  Above EQ <> Above EQ = Above EQ
+  Above EQ <> Above GT = Above GT
+  Above GT <> Above EQ = Above GT
+  Above GT <> Above GT = Above GT
+
+instance Monoid Above where
+  mempty = Above LT
+
+-- | So it shall be below.
+--
+-- @Below@ provides the monoid associated with the intersection of downward-directed sets.
+newtype Below = Below { getBelow :: Ordering }
+  deriving
+    ( Bounded
+    , Enum
+    , Eq
+    , Generic
+    , Show
+    , Read
+#if MIN_VERSION_base(4,7,0)
+    , Data
+    , Typeable
+#endif
+    )
+
+instance Semigroup Below where
+  Below GT <> a = a
+  a <> Below GT = a
+  Below EQ <> Below EQ = Below EQ
+  Below EQ <> Below LT = Below LT
+  Below LT <> Below EQ = Below LT
+  Below LT <> Below LT = Below LT
+
+instance Monoid Below where
+  mempty = Below GT
+
+-- | Wrapper for the semiring of upwards and downwards directed sets.
+--
+-- For the individual join/meet monoids associated with either
+-- algebra, see 'Above', and 'Below'.
+newtype Directed = Directed { getDirected :: Ordering }
+  deriving
+    ( Bounded
+    , Enum
+    , Eq
+    , Generic
+    , Show
+    , Read
+#if MIN_VERSION_base(4,7,0)
+    , Data
+    , Typeable
+#endif
+    )
+
+instance Semiring Directed where
+  plus = coerce ((<>) :: Above -> Above -> Above)
+  zero = coerce (mempty :: Above)
+  times = coerce ((<>) :: Below -> Below -> Below)
+  one = coerce (mempty :: Below)

--- a/semirings.cabal
+++ b/semirings.cabal
@@ -69,6 +69,7 @@ library
     Data.Field
     Data.Semiring
     Data.Star
+    Data.Semiring.Directed
     Data.Semiring.Tropical
     Data.Semiring.Generic
 

--- a/semirings.cabal
+++ b/semirings.cabal
@@ -1,6 +1,6 @@
 name:          semirings
 category:      Algebra, Data, Data Structures, Math, Maths, Mathematics
-version:       0.6
+version:       0.7
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE


### PR DESCRIPTION
This is based on an idea of @emilypi's which we decided to hack together. It provides a newtype wrapper around `Ordering`, allowing it to have a `Semiring` instance. 

I don't know whether the versioning policy requires a bump, but I put one in anyway.