### PR TITLE
OrderedRing type class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 0.7: [2021-07-09]
 -----------------
 * Add `Data.Semiring.Directed` for the semiring of directed sets.
+* Add `Data.Ring.Ordered` to represent ordered rings (as well as a simpler
+  finitary case) and provide `signum` and `abs` via type class.
 
 0.6: [2021-01-07]
 -----------------

--- a/Data/Ring/Ordered.hs
+++ b/Data/Ring/Ordered.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE Trustworthy                #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 -- |
 -- Module: Data.Ring.Ordered
@@ -70,6 +72,18 @@ data Signum = Negative | Zero | Positive
     , Typeable -- ^ @since 0.7
 #endif
     )
+
+-- @since 0.7
+instance Semigroup Signum where
+  Zero <> _ = Zero
+  _ <> Zero = Zero
+  Positive <> Positive = Positive
+  Negative <> Negative = Positive
+  _ <> _ = Negative
+
+-- @since 0.7
+instance Monoid Signum where
+  mempty = Positive
 
 -- | The class of rings which also have a total order.
 --
@@ -197,3 +211,8 @@ instance OrderedRing Integer where
     (-1) -> Negative
     0 -> Zero
     _ -> Positive
+
+-- @since 0.7
+instance (Ring (a, b), OrderedRing a, OrderedRing b) => OrderedRing (a, b) where
+  abs (x, y) = (abs x, abs y)
+  signum (x, y) = signum x <> signum y

--- a/Data/Ring/Ordered.hs
+++ b/Data/Ring/Ordered.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE Trustworthy                #-}
+
+-- |
+-- Module: Data.Ring.Ordered
+-- Copyright: (C) 2021 Koz Ross
+-- License: 
+-- Maintainer: Koz Ross <koz.ross@retro-freedom.nz>
+-- Stability: stable
+-- Portability: GHC only
+--
+-- An \'ordered ring\' is a ring with a total order.
+--
+-- = Mathematical pedantry note
+--
+-- Many (if not most) of the instances of the 'OrderedRing' type class are not
+-- truly ordered rings in the mathematical sense, as the
+-- [axioms](https://en.wikipedia.org/wiki/Ordered_ring) imply that the
+-- underlying set is either a singleton or infinite. Thus, the [additional
+-- properties](https://en.wikipedia.org/wiki/Ordered_ring#Basic_properties) of
+-- ordered rings do not, in general, hold. The only exception is that for any
+-- @OrderedRing a => x :: a@, @x@ is either positive (that is, @'signum' x ==
+-- 'Positive'@), negative (that is, @'signum' x == 'Negative'@) or @zero@.
+--
+-- We indicate those instances that /are/ \'truly\' or \'mathematically\'
+-- ordered rings in their documentation.
+module Data.Ring.Ordered 
+  (
+    -- * Helper type
+    Signum(..),
+    -- * Ordered ring type class
+    OrderedRing(..)
+  ) where
+
+import Control.Applicative (Const (Const))
+#if MIN_VERSION_base(4,7,0)
+import Data.Data (Data)
+#endif
+import Data.Fixed (HasResolution, Fixed)
+import Data.Functor.Identity (Identity (Identity))
+import Data.Int (Int8, Int16, Int32, Int64)
+import Data.Ord (Down (Down))
+import Data.Ratio (Ratio)
+import Data.Semiring (Ring (negate), zero)
+import Data.Monoid (Dual (Dual))
+import GHC.Generics (Generic)
+import Prelude hiding (signum, abs, negate, (-))
+import qualified Prelude as Num
+#if MIN_VERSION_base(4,7,0)
+import Data.Typeable (Typeable)
+#endif
+
+-- | A pattern-matching-friendly representation of the signum of a value.
+--
+-- @since 0.7
+data Signum = Negative | Zero | Positive
+  deriving
+    ( Bounded -- ^ @since 0.7
+    , Eq -- ^ @since 0.7
+    , Ord -- ^ @since 0.7
+    , Show -- ^ @since 0.7
+    , Read -- ^ @since 0.7
+    , Generic -- ^ @since 0.7
+#if MIN_VERSION_base(4,7,0)
+    , Data -- ^ @since 0.7
+    , Typeable -- ^ @since 0.7
+#endif
+    )
+
+-- | The class of rings which also have a total order.
+--
+-- Instance should satisfy the following laws:
+--
+-- * @'abs' 'zero' = 'zero'@
+-- * @'abs' x = 'abs' ('negate' x)@
+-- * @x 'Data.Semiring.-' 'abs' x = 'zero'@
+-- * @'signum' 'zero' = 'Zero'@
+-- * If @x '>' 'zero'@, then @'signum' x = 'Positive'@
+-- * If @x '<' 'zero'@, then @'signum' x = 'Negative'@
+--
+-- Additionally, if you define both 'signum' and 'abs', the implementations 
+-- are subject to the following consistency laws:
+--
+-- * @'signum' x = 'Negative'@ if and only if @'abs' x /= x@
+--
+-- @since 0.7
+class (Ring a, Ord a) => OrderedRing a where
+#if __GLASGOW_HASKELL__ >= 708
+  {-# MINIMAL abs | signum #-}
+#endif
+  -- | Compute the absolute value.
+  abs :: a -> a
+  abs x = case signum x of 
+    Negative -> negate x
+    _ -> x
+  -- | Determine the \'sign\' of a value.
+  signum :: a -> Signum
+  signum x 
+    | x == zero = Zero
+    | x == abs x = Positive
+    | otherwise = Negative
+
+-- | This instance is a \'true\' or \'mathematical\' ordered ring, as it is a
+-- singleton. We assume that '()' has a zero signum.
+--
+-- @since 0.7
+instance OrderedRing () where
+  abs = const ()
+  signum = const Zero
+
+-- | @since 0.7
+instance (OrderedRing a) => OrderedRing (Dual a) where
+  abs (Dual x) = Dual . abs $ x
+  signum (Dual x) = signum x
+
+-- | @since 0.7
+instance (OrderedRing a) => OrderedRing (Const a b) where
+  abs (Const x) = Const . abs $ x
+  signum (Const x) = signum x
+
+-- | Where @a ~ 'Integer'@, this instance is a \'true\' or \'mathematical\'
+-- ordered ring, as the resulting type is infinite.
+--
+-- @since 0.7
+instance (Integral a) => OrderedRing (Ratio a) where
+  abs = Num.abs
+  signum x = case Num.signum x of 
+    (-1) -> Negative
+    0 -> Zero
+    _ -> Positive
+
+-- | @since 0.7
+deriving instance (OrderedRing a) => OrderedRing (Down a)
+
+-- | @since 0.7
+deriving instance (OrderedRing a) => OrderedRing (Identity a)
+
+-- | @since 0.7
+instance (HasResolution a) => OrderedRing (Fixed a) where
+  abs = Num.abs
+  signum x = case Num.signum x of 
+    (-1) -> Negative
+    0 -> Zero
+    _ -> Positive
+
+-- | @since 0.7
+instance OrderedRing Int8 where
+  abs = Num.abs
+  signum x = case Num.signum x of 
+    (-1) -> Negative
+    0 -> Zero
+    _ -> Positive
+
+-- | @since 0.7
+instance OrderedRing Int16 where
+  abs = Num.abs
+  signum x = case Num.signum x of 
+    (-1) -> Negative
+    0 -> Zero
+    _ -> Positive
+
+-- | @since 0.7
+instance OrderedRing Int32 where
+  abs = Num.abs
+  signum x = case Num.signum x of 
+    (-1) -> Negative
+    0 -> Zero
+    _ -> Positive
+
+-- | @since 0.7
+instance OrderedRing Int64 where
+  abs = Num.abs
+  signum x = case Num.signum x of 
+    (-1) -> Negative
+    0 -> Zero
+    _ -> Positive
+
+-- | @since 0.7
+instance OrderedRing Int where
+  abs = Num.abs
+  signum x = case Num.signum x of 
+    (-1) -> Negative
+    0 -> Zero
+    _ -> Positive
+
+-- | This instance is a \'true\' or \'mathematical\' ordered ring, as 'Integer'
+-- is an infinite type.
+--
+-- @since 0.7
+instance OrderedRing Integer where
+  abs = Num.abs
+  signum x = case Num.signum x of 
+    (-1) -> Negative
+    0 -> Zero
+    _ -> Positive

--- a/Data/Ring/Ordered.hs
+++ b/Data/Ring/Ordered.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE Trustworthy                #-}
-{-# LANGUAGE UndecidableInstances       #-}
 
 -- |
 -- Module: Data.Ring.Ordered
@@ -51,6 +50,7 @@ import Data.Monoid (Dual (Dual))
 import Data.Ord (Down (Down))
 import Data.Ratio (Ratio)
 import Data.Semiring (Ring (negate), Semiring(zero, one))
+import Data.Semiring.Generic ()
 import Data.Word (Word8, Word16, Word32, Word64)
 import GHC.Generics (Generic)
 import Prelude hiding (signum, abs, negate, (-))
@@ -346,11 +346,32 @@ instance OrderedRing (Modular Word) where
     | otherwise = Positive
   signum' (Modular x) = Modular . Num.signum $ x
 
--- Where @a@ and @b@ are both \'true\' or \'mathematical\' ordered rings, so is 
+-- | Where @a@ and @b@ are both \'true\' or \'mathematical\' ordered rings, so is 
 -- this.
 --
 -- @since 0.7
-instance (Ring (a, b), OrderedRing a, OrderedRing b) => OrderedRing (a, b) where
+instance (OrderedRing a, OrderedRing b) => 
+  OrderedRing (a, b) where
   abs (x, y) = (abs x, abs y)
   signum (x, y) = signum x <> signum y
   signum' (x, y) = (signum' x, signum' y)
+
+-- | Where all of @a@, @b@, @c@ are \'true\' or \'mathematical\' ordered rings,
+-- so is this.
+--
+-- @since 0.7
+instance (OrderedRing a, OrderedRing b, OrderedRing c) =>
+  OrderedRing (a, b, c) where
+  abs (x, y, z) = (abs x, abs y, abs z)
+  signum (x, y, z) = signum x <> signum y <> signum z
+  signum' (x, y, z) = (signum' x, signum' y, signum' z)
+
+-- | Where all of @a@, @b@, @c@, @d@ are \'true\' or \'mathematical\' ordered
+-- rings, so is this.
+--
+-- @since 0.7
+instance (OrderedRing a, OrderedRing b, OrderedRing c, OrderedRing d) =>
+  OrderedRing (a, b, c, d) where
+  abs (x, y, z, z2) = (abs x, abs y, abs z, abs z2)
+  signum (x, y, z, z2) = signum x <> signum y <> signum z <> signum z2
+  signum' (x, y, z, z2) = (signum' x, signum' y, signum' z, signum' z2)

--- a/Data/Semiring/Directed.hs
+++ b/Data/Semiring/Directed.hs
@@ -93,8 +93,8 @@ instance Semigroup Below where
   Below GT <> a = a
   a <> Below GT = a
   Below EQ <> Below EQ = Below EQ
-  Below EQ <> _ = Below LT
-  _ <> Below EQ = Below LT
+  Below LT <> _ = Below LT
+  _ <> Below LT = Below LT
 
 -- | @since 0.7
 instance Monoid Below where

--- a/semirings.cabal
+++ b/semirings.cabal
@@ -67,6 +67,7 @@ library
   exposed-modules:
     Data.Euclidean
     Data.Field
+    Data.Ring.Ordered
     Data.Semiring
     Data.Star
     Data.Semiring.Directed


### PR DESCRIPTION
This is based on an idea and a set of chats between me and @emilypi. I've had to take a slightly [Procrustean](https://www.schoolofhaskell.com/user/edwardk/editorial/procrustean-mathematics) approach to instances, as [mathematically-speaking](https://en.wikipedia.org/wiki/Ordered_ring), ordered rings have to be infinite or trivial. I've kept the instances fairly narrow in scope as well, but if the maintainers feel we need more, I can add them.

I felt that jamming `OrderedRing` into `Data.Semiring` didn't make much sense, so I decided to put it into its current module. It's a bit jarring given that `Ring` currently lives in `Data.Semiring` (and not `Data.Ring`), but I figured that's a change for another PR, and probably only with maintainer agreement.