### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
-        ghc: ['8.6', '8.8', '8.10', '9.0']
-        include:
-        - os: windows-latest
-          ghc: 'latest'
-        - os: macOS-latest
-          ghc: 'latest'
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
     steps:
     - uses: actions/checkout@v2
     - uses: haskell/actions/setup@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,5 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.ghc }}
     - name: Test
       run: cabal test
-    - name: Haddock
-      run: cabal haddock
+#    - name: Haddock
+#      run: cabal haddock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,5 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.ghc }}
     - name: Build
       run: cabal build
-    - name: Test
-      run: cabal test
 #    - name: Haddock
 #      run: cabal haddock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           dist-newstyle
         key: ${{ runner.os }}-${{ matrix.ghc }}
+    - name: Build
+      run: cabal build
     - name: Test
       run: cabal test
 #    - name: Haddock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add `Data.Semiring.Directed` for the semiring of directed sets.
 * Add `Data.Ring.Ordered` to represent ordered rings (as well as a simpler
   finitary case) and provide `signum` and `abs` via type class.
+* Modify code and CI to support GHC 8.0 and later only.
 
 0.6: [2021-01-07]
 -----------------

--- a/Data/Ring/Ordered.hs
+++ b/Data/Ring/Ordered.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
@@ -37,9 +36,7 @@ module Data.Ring.Ordered
   ) where
 
 import Control.Applicative (Const (Const))
-#if MIN_VERSION_base(4,7,0)
 import Data.Data (Data)
-#endif
 import Data.Fixed (HasResolution, Fixed)
 import Data.Functor.Identity (Identity (Identity))
 import Data.Int (Int8, Int16, Int32, Int64)
@@ -51,9 +48,7 @@ import Data.Word (Word8, Word16, Word32, Word64)
 import GHC.Generics (Generic)
 import Prelude hiding (signum, abs, negate, (-))
 import qualified Prelude as Num
-#if MIN_VERSION_base(4,7,0)
 import Data.Typeable (Typeable)
-#endif
 
 -- | A wrapper to indicate the type is being treated as a [modular arithmetic
 -- system](https://en.wikipedia.org/wiki/Modular_arithmetic) whose modulus is
@@ -72,10 +67,8 @@ newtype Modular a = Modular { getModular :: a }
     , Show -- ^ @since 0.7
     , Read -- ^ @since 0.7
     , Generic -- ^ @since 0.7
-#if MIN_VERSION_base(4,7,0)
     , Data -- ^ @since 0.7
     , Typeable -- ^ @since 0.7
-#endif
     )
 
 -- @since 0.7

--- a/Data/Semiring.hs
+++ b/Data/Semiring.hs
@@ -495,6 +495,72 @@ fromIntegral x
   Instances (base)
 --------------------------------------------------------------------}
 
+instance (Semiring a, Semiring b) => Semiring (a,b) where
+  zero = (zero, zero)
+  one = (one, one)
+  plus (x1, x2) (y1, y2) =
+    (x1 `plus` y1, x2 `plus` y2)
+  times (x1, x2) (y1, y2) =
+    (x1 `times` y1, x2 `times` y2)
+
+instance (Semiring a, Semiring b, Semiring c) => Semiring (a,b,c) where
+  zero = (zero, zero, zero)
+  one = (one, one, one)
+  plus (x1, x2, x3) (y1, y2, y3) =
+    (x1 `plus` y1, x2 `plus` y2, x3 `plus` y3)
+  times (x1, x2, x3) (y1, y2, y3) =
+    (x1 `times` y1, x2 `times` y2, x3 `times` y3)
+
+instance (Semiring a, Semiring b, Semiring c, Semiring d) => Semiring (a,b,c,d) where
+  zero = (zero, zero, zero, zero)
+  one = (one, one, one, one)
+  plus (x1, x2, x3, x4) (y1, y2, y3, y4) =
+    (x1 `plus` y1, x2 `plus` y2, x3 `plus` y3, x4 `plus` y4)
+  times (x1, x2, x3, x4) (y1, y2, y3, y4) =
+    (x1 `times` y1, x2 `times` y2, x3 `times` y3, x4 `times` y4)
+
+instance (Semiring a, Semiring b, Semiring c, Semiring d, Semiring e) => Semiring (a,b,c,d,e) where
+  zero = (zero, zero, zero, zero, zero)
+  one = (one, one, one, one, one)
+  plus (x1, x2, x3, x4, x5) (y1, y2, y3, y4, y5) =
+    (x1 `plus` y1, x2 `plus` y2, x3 `plus` y3, x4 `plus` y4, x5 `plus` y5)
+  times (x1, x2, x3, x4, x5) (y1, y2, y3, y4, y5) =
+    (x1 `times` y1, x2 `times` y2, x3 `times` y3, x4 `times` y4, x5 `times` y5)
+
+instance (Semiring a, Semiring b, Semiring c, Semiring d, Semiring e, Semiring f) => Semiring (a,b,c,d,e,f) where
+  zero = (zero, zero, zero, zero, zero, zero)
+  one = (one, one, one, one, one, one)
+  plus (x1, x2, x3, x4, x5, x6) (y1, y2, y3, y4, y5, y6) =
+    (x1 `plus` y1, x2 `plus` y2, x3 `plus` y3, x4 `plus` y4, x5 `plus` y5, x6 `plus` y6)
+  times (x1, x2, x3, x4, x5, x6) (y1, y2, y3, y4, y5, y6) =
+    (x1 `times` y1, x2 `times` y2, x3 `times` y3, x4 `times` y4, x5 `times` y5, x6 `times` y6)
+
+instance (Semiring a, Semiring b, Semiring c, Semiring d, Semiring e, Semiring f, Semiring g) => Semiring (a,b,c,d,e,f,g) where
+  zero = (zero, zero, zero, zero, zero, zero, zero)
+  one = (one, one, one, one, one, one, one)
+  plus (x1, x2, x3, x4, x5, x6, x7) (y1, y2, y3, y4, y5, y6, y7) =
+    (x1 `plus` y1, x2 `plus` y2, x3 `plus` y3, x4 `plus` y4, x5 `plus` y5, x6 `plus` y6, x7 `plus` y7)
+  times (x1, x2, x3, x4, x5, x6, x7) (y1, y2, y3, y4, y5, y6, y7) =
+    (x1 `times` y1, x2 `times` y2, x3 `times` y3, x4 `times` y4, x5 `times` y5, x6 `times` y6, x7 `times` y7)
+
+instance (Ring a, Ring b) => Ring (a,b) where
+  negate (x1, x2) = (negate x1, negate x2)
+
+instance (Ring a, Ring b, Ring c) => Ring (a,b,c) where
+  negate (x1, x2, x3) = (negate x1, negate x2, negate x3)
+
+instance (Ring a, Ring b, Ring c, Ring d) => Ring (a,b,c,d) where
+  negate (x1, x2, x3, x4) = (negate x1, negate x2, negate x3, negate x4)
+
+instance (Ring a, Ring b, Ring c, Ring d, Ring e) => Ring (a,b,c,d,e) where
+  negate (x1, x2, x3, x4, x5) = (negate x1, negate x2, negate x3, negate x4, negate x5)
+
+instance (Ring a, Ring b, Ring c, Ring d, Ring e, Ring f) => Ring (a,b,c,d,e,f) where
+  negate (x1, x2, x3, x4, x5, x6) = (negate x1, negate x2, negate x3, negate x4, negate x5, negate x6)
+
+instance (Ring a, Ring b, Ring c, Ring d, Ring e, Ring f, Ring g) => Ring (a,b,c,d,e,f,g) where
+  negate (x1, x2, x3, x4, x5, x6, x7) = (negate x1, negate x2, negate x3, negate x4, negate x5, negate x6, negate x7)
+
 instance Semiring b => Semiring (a -> b) where
   plus f g    = \x -> f x `plus` g x
   zero        = const zero

--- a/Data/Semiring.hs
+++ b/Data/Semiring.hs
@@ -99,7 +99,7 @@ import           Data.Ord (Ord((<)), (>=))
 import           Data.Ord (Down(..))
 import           Data.Proxy (Proxy(..))
 import           Data.Ratio (Ratio, Rational, (%))
-import           Data.Semigroup.Compat (Semigroup(..))
+import           Data.Semigroup (Semigroup ((<>), stimes))
 #if defined(VERSION_containers)
 import           Data.Set (Set)
 import qualified Data.Set as Set

--- a/Data/Semiring.hs
+++ b/Data/Semiring.hs
@@ -57,7 +57,7 @@ module Data.Semiring
   ) where
 
 import           Control.Applicative (Applicative(..), Const(..), liftA2)
-import           Data.Bits (Bits)
+import           Data.Bits (Bits (xor))
 import           Data.Bool (Bool(..), (||), (&&), otherwise)
 import           Data.Coerce (Coercible, coerce)
 import           Data.Complex (Complex(..))
@@ -87,12 +87,10 @@ import           Data.Maybe (Maybe(..))
 import           Data.Monoid (Ap(..))
 #endif
 #if defined(VERSION_containers)
-#if MIN_VERSION_base(4,7,0)
 import           Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import           Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
-#endif
 import           Data.Map (Map)
 import qualified Data.Map as Map
 #endif
@@ -392,10 +390,7 @@ newtype Mod2 = Mod2 { getMod2 :: Bool }
     )
 
 instance Semiring Mod2 where
-  -- we inline the definition of 'xor'
-  -- on Bools, since the instance did not exist until
-  -- base-4.7.0.
-  plus (Mod2 x) (Mod2 y) = Mod2 (x /= y)
+  plus (Mod2 x) (Mod2 y) = Mod2 (x `xor` y)
   times (Mod2 x) (Mod2 y) = Mod2 (x && y)
   zero = Mod2 False
   one = Mod2 True
@@ -449,9 +444,7 @@ instance Ring Mod2 where
 --     @'zero' '*' x = x '*' 'zero' = 'zero'@
 
 class Semiring a where
-#if __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL plus, times, (zero, one | fromNatural) #-}
-#endif
   plus  :: a -> a -> a -- ^ Commutative Operation
   zero  :: a           -- ^ Commutative Unit
   zero = fromNatural 0
@@ -467,9 +460,7 @@ class Semiring a where
 --     @'negate' a '+' a = 'zero'@
 
 class Semiring a => Ring a where
-#if __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL negate #-}
-#endif
   negate :: a -> a
 
 -- | Subtract two 'Ring' values. For any type @R@ with

--- a/Data/Semiring/Directed.hs
+++ b/Data/Semiring/Directed.hs
@@ -18,19 +18,15 @@ module Data.Semiring.Directed
     Directed(..)
   ) where
 
-#if MIN_VERSION_base(4,7,0)
 import Data.Data (Data)
-#endif
 import Data.Coerce (coerce)
 import Data.Semiring (Semiring(..))
-#if MIN_VERSION_base(4,7,0)
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Min(Min), Max(Max))
 #else
 import Data.Semigroup.Compat (Min(Min), Max(Max))
 #endif
 import Data.Typeable (Typeable)
-#endif
 import GHC.Generics (Generic)
 
 -- | Wrapper for the semiring of upwards and downwards directed sets.
@@ -41,17 +37,23 @@ newtype Directed = Directed {
   -- | @since 0.7
   getDirected :: Ordering 
   }
-  deriving
-    ( Bounded -- ^ @since 0.7
-    , Enum -- ^ @since 0.7
-    , Eq -- ^ @since 0.7
-    , Generic  -- ^ @since 0.7
-    , Show -- ^ @since 0.7
-    , Read -- ^ @since 0.7
-#if MIN_VERSION_base(4,7,0)
-    , Data -- ^ @since 0.7
-    , Typeable -- ^ @since 0.7
-#endif
+  deriving ( 
+    -- | @since 0.7
+    Bounded, 
+    -- | @since 0.7
+    Enum,
+    -- | @since 0.7
+    Eq,
+    -- | @since 0.7
+    Generic,
+    -- | @since 0.7
+    Show,
+    -- | @since 0.7
+    Read,
+    -- | @since 0.7
+    Data,
+    -- | @since 0.7
+    Typeable 
     )
 
 -- | @since 0.7

--- a/Data/Semiring/Directed.hs
+++ b/Data/Semiring/Directed.hs
@@ -21,11 +21,7 @@ module Data.Semiring.Directed
 import Data.Data (Data)
 import Data.Coerce (coerce)
 import Data.Semiring (Semiring(..))
-#if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Min(Min), Max(Max))
-#else
-import Data.Semigroup.Compat (Min(Min), Max(Max))
-#endif
+import Data.Semigroup (Min(Min), Max(Max), (<>))
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 

--- a/Data/Semiring/Generic.hs
+++ b/Data/Semiring/Generic.hs
@@ -3,10 +3,6 @@
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- below are safe orphan instances
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semiring.Generic
@@ -51,42 +47,6 @@ instance (Generic a, GSemiring (Rep a)) => Semiring (GenericSemiring a) where
   plus (GenericSemiring x) (GenericSemiring y) = GenericSemiring (gplus x y)
   times (GenericSemiring x) (GenericSemiring y) = GenericSemiring (gtimes x y)
   fromNatural x = GenericSemiring (gfromNatural x)
-
-instance (Semiring a, Semiring b) => Semiring (a,b) where
-  zero = gzero; one = gone; plus = gplus; times = gtimes; fromNatural = gfromNatural;
-
-instance (Semiring a, Semiring b, Semiring c) => Semiring (a,b,c) where
-  zero = gzero; one = gone; plus = gplus; times = gtimes; fromNatural = gfromNatural;
-
-instance (Semiring a, Semiring b, Semiring c, Semiring d) => Semiring (a,b,c,d) where
-  zero = gzero; one = gone; plus = gplus; times = gtimes; fromNatural = gfromNatural;
-
-instance (Semiring a, Semiring b, Semiring c, Semiring d, Semiring e) => Semiring (a,b,c,d,e) where
-  zero = gzero; one = gone; plus = gplus; times = gtimes; fromNatural = gfromNatural;
-
-instance (Semiring a, Semiring b, Semiring c, Semiring d, Semiring e, Semiring f) => Semiring (a,b,c,d,e,f) where
-  zero = gzero; one = gone; plus = gplus; times = gtimes; fromNatural = gfromNatural;
-
-instance (Semiring a, Semiring b, Semiring c, Semiring d, Semiring e, Semiring f, Semiring g) => Semiring (a,b,c,d,e,f,g) where
-  zero = gzero; one = gone; plus = gplus; times = gtimes; fromNatural = gfromNatural;
-
-instance (Ring a, Ring b) => Ring (a,b) where
-  negate = gnegate
-
-instance (Ring a, Ring b, Ring c) => Ring (a,b,c) where
-  negate = gnegate
-
-instance (Ring a, Ring b, Ring c, Ring d) => Ring (a,b,c,d) where
-  negate = gnegate
-
-instance (Ring a, Ring b, Ring c, Ring d, Ring e) => Ring (a,b,c,d,e) where
-  negate = gnegate
-
-instance (Ring a, Ring b, Ring c, Ring d, Ring e, Ring f) => Ring (a,b,c,d,e,f) where
-  negate = gnegate
-
-instance (Ring a, Ring b, Ring c, Ring d, Ring e, Ring f, Ring g) => Ring (a,b,c,d,e,f,g) where
-  negate = gnegate
 
 {--------------------------------------------------------------------
   Generics

--- a/Data/Semiring/Generic.hs
+++ b/Data/Semiring/Generic.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE CPP                  #-}
-#if MIN_VERSION_base(4,6,0)
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
-#endif
 
 -- below are safe orphan instances
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -27,7 +24,6 @@
 
 module Data.Semiring.Generic
   (
-#if MIN_VERSION_base(4,6,0)
     GSemiring(..)
   , gzero
   , gone
@@ -37,10 +33,8 @@ module Data.Semiring.Generic
   , GRing(..)
   , gnegate
   , GenericSemiring(..)
-#endif
   ) where
 
-#if MIN_VERSION_base(4,6,0)
 import           Data.Semiring
 import           GHC.Generics
 import           Numeric.Natural (Natural)
@@ -101,9 +95,7 @@ instance (Ring a, Ring b, Ring c, Ring d, Ring e, Ring f, Ring g) => Ring (a,b,c
 -- | Generic 'Semiring' class, used to implement 'plus', 'times', 'zero',
 --   and 'one' for product-like types implementing 'Generic'.
 class GSemiring f where
-#if __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL gplus', gzero', gtimes', gone', gfromNatural' #-}
-#endif
   gzero'  :: f a
   gone'   :: f a
   gplus'  :: f a -> f a -> f a
@@ -113,9 +105,7 @@ class GSemiring f where
 -- | Generic 'Ring' class, used to implement 'negate' for product-like
 --   types implementing 'Generic'.
 class GRing f where
-#if __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL gnegate' #-}
-#endif
   gnegate' :: f a -> f a
 
 -- | Generically generate a 'Semiring' 'zero' for any product-like type
@@ -214,4 +204,3 @@ instance (Semiring a) => GSemiring (K1 i a) where
 
 instance (Ring a) => GRing (K1 i a) where
   gnegate' (K1 x) = K1 $ negate x
-#endif

--- a/Data/Semiring/Tropical.hs
+++ b/Data/Semiring/Tropical.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE KindSignatures      #-}
@@ -31,14 +30,10 @@ module Data.Semiring.Tropical
   , EProxy(EProxy)
   ) where
 
-#if MIN_VERSION_base(4,7,0)
 import Data.Data (Data)
-#endif
 import Data.Semiring (Semiring(..))
 import Data.Star (Star(..))
-#if MIN_VERSION_base(4,7,0)
 import Data.Typeable (Typeable)
-#endif
 
 -- done for haddocks, to make sure -Wall works
 import qualified Data.Monoid as Monoid
@@ -94,10 +89,8 @@ data Tropical (e :: Extrema) a
     ( Eq
     , Show
     , Read
-#if MIN_VERSION_base(4,7,0)
     , Typeable
     , Data
-#endif
     )
 
 instance forall e a. (Ord a, Extremum e) => Ord (Tropical e a) where

--- a/Data/Star.hs
+++ b/Data/Star.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -----------------------------------------------------------------------------
@@ -25,9 +24,7 @@ import Data.Semiring
 --
 -- @'aplus' x = x '*' 'star' x@
 class (Semiring a) => Star a where
-#if __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL star | aplus #-}
-#endif
   star :: a -> a
   star a = one `plus` aplus a
 

--- a/semirings.cabal
+++ b/semirings.cabal
@@ -29,10 +29,13 @@ description:
 
 build-type:    Simple
 extra-source-files: README.md CHANGELOG.md
-tested-with:   GHC == 8.6.5
-             , GHC == 8.8.4
-             , GHC == 8.10.4
-             , GHC == 9.0.1
+tested-with:   GHC == 8.0
+             , GHC == 8.2
+             , GHC == 8.4
+             , GHC == 8.6
+             , GHC == 8.8
+             , GHC == 8.10
+             , GHC == 9.0
 
 source-repository head
   type: git
@@ -60,7 +63,6 @@ library
 
   build-depends:
       base >= 4.8 && < 5
-    , base-compat-batteries
   exposed-modules:
     Data.Euclidean
     Data.Field


### PR DESCRIPTION
This addresses #73's cleanup. In particular:

* `Generics`-based orphans have been moved to `Data.Semiring`
* CI has been modified to check the entire support window on all platforms
* CPP use for anything before 8.0 is gone
* No compatibility dependencies for `base`

I had to disable Haddock for now, as for some reason, it always fails on 8.4.