### PR TITLE
Restore Haddocks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
+        ghc: ['8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
     steps:
     - uses: actions/checkout@v2
     - uses: haskell/actions/setup@v1
@@ -32,7 +32,9 @@ jobs:
           ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           dist-newstyle
         key: ${{ runner.os }}-${{ matrix.ghc }}
+    - name: Configure
+      run: cabal configure --enable-documentation
     - name: Build
       run: cabal build
-#    - name: Haddock
-#      run: cabal haddock
+    - name: Haddock
+      run: cabal haddock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        ghc: ['8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
     steps:
     - uses: actions/checkout@v2
     - uses: haskell/actions/setup@v1

--- a/Data/Ring/Ordered.hs
+++ b/Data/Ring/Ordered.hs
@@ -61,14 +61,14 @@ import Data.Typeable (Typeable)
 -- @since 0.7
 newtype Modular a = Modular { getModular :: a }
   deriving
-    ( Bounded -- ^ @since 0.7
-    , Eq -- ^ @since 0.7
-    , Ord -- ^ @since 0.7
-    , Show -- ^ @since 0.7
-    , Read -- ^ @since 0.7
-    , Generic -- ^ @since 0.7
-    , Data -- ^ @since 0.7
-    , Typeable -- ^ @since 0.7
+    ( Bounded 
+    , Eq 
+    , Ord
+    , Show
+    , Read
+    , Generic
+    , Data
+    , Typeable
     )
 
 -- @since 0.7

--- a/Data/Semiring/Directed.hs
+++ b/Data/Semiring/Directed.hs
@@ -33,15 +33,15 @@ import GHC.Generics (Generic)
 -- @since 0.7
 newtype Directed = Directed { getDirected :: Ordering }
   deriving
-    ( Bounded -- ^ @since 0.7
-    , Eq -- ^ @since 0.7
-    , Enum -- ^ @since 0.7
-    , Ord -- ^ @since 0.7
-    , Show -- ^ @since 0.7
-    , Read -- ^ @since 0.7
-    , Generic -- ^ @since 0.7
-    , Data -- ^ @since 0.7
-    , Typeable -- ^ @since 0.7
+    ( Bounded 
+    , Eq 
+    , Enum 
+    , Ord 
+    , Show
+    , Read
+    , Generic
+    , Data
+    , Typeable
     )
 
 -- | @since 0.7

--- a/Data/Semiring/Directed.hs
+++ b/Data/Semiring/Directed.hs
@@ -29,27 +29,19 @@ import GHC.Generics (Generic)
 --
 -- For the individual join/meet monoids associated with either
 -- algebra, see @'Max' 'Ordering', and @'Min' 'Ordering'@.
-newtype Directed = Directed { 
-  -- | @since 0.7
-  getDirected :: Ordering 
-  }
-  deriving ( 
-    -- | @since 0.7
-    Bounded, 
-    -- | @since 0.7
-    Enum,
-    -- | @since 0.7
-    Eq,
-    -- | @since 0.7
-    Generic,
-    -- | @since 0.7
-    Show,
-    -- | @since 0.7
-    Read,
-    -- | @since 0.7
-    Data,
-    -- | @since 0.7
-    Typeable 
+--
+-- @since 0.7
+newtype Directed = Directed { getDirected :: Ordering }
+  deriving
+    ( Bounded -- ^ @since 0.7
+    , Eq -- ^ @since 0.7
+    , Enum -- ^ @since 0.7
+    , Ord -- ^ @since 0.7
+    , Show -- ^ @since 0.7
+    , Read -- ^ @since 0.7
+    , Generic -- ^ @since 0.7
+    , Data -- ^ @since 0.7
+    , Typeable -- ^ @since 0.7
     )
 
 -- | @since 0.7

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ http://r6.ca/blog/20110808T035622Z.html
 
 https://byorgey.wordpress.com/2016/04/05/the-network-reliability-problem-and-star-semirings/
 
+support window
+==============
+
+We support all GHCs from 8.0 onwards. Our CI currently checks the latest minor
+versions of the following GHCs:
+
+- 8.0
+- 8.2
+- 8.4
+- 8.6
+- 8.8
+- 9.0
+
+We support Windows, macOS and Linux: our CI checks all of them (with Ubuntu for
+the last).
+
 additional credit
 ======
 


### PR DESCRIPTION
The issue with Haddocks in #78  was that GHC 8.0's `haddock` will not render `@since` annotations on derivations in absolutely any form. Thus, if we support 8.0, we can't have them.

To this end, I have removed such `@since`s, and restored Haddocks to the CI.

@chessai - is there any particular reason why 8.0 support is desirable? Such annotations are extremely useful documentation, and by supporting it, we're currently losing access to them.